### PR TITLE
Enhance download to support offline builds

### DIFF
--- a/Tailwind.Standalone.csproj
+++ b/Tailwind.Standalone.csproj
@@ -10,7 +10,7 @@
 
     <Authors>Marshal Hayes</Authors>
     <PackageId>MarshalHayes.Tailwind.Standalone</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Description>Use the Tailwind Standalone CLI the right way</Description>
     
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/build/MarshalHayes.Tailwind.Standalone.targets
+++ b/build/MarshalHayes.Tailwind.Standalone.targets
@@ -68,14 +68,20 @@
 
       <TailwindDownloadUrl Condition="'$(TailwindDownloadUrl)' == '' And $(TailwindVersion) != 'latest'">https://github.com/tailwindlabs/tailwindcss/releases/download/$(TailwindVersion)/$(TailwindReleaseName)</TailwindDownloadUrl>
       <TailwindDownloadUrl Condition="'$(TailwindDownloadUrl)' == '' And $(TailwindVersion) == 'latest'">https://github.com/tailwindlabs/tailwindcss/releases/latest/download/$(TailwindReleaseName)</TailwindDownloadUrl>
+
+      <TailwindDestinationFolder>$([System.IO.Path]::Combine('$(TailwindDownloadPath)', 'Tailwind', '$(TailwindVersion)'))</TailwindDestinationFolder>
+
+      <TailwindCliPath>$([System.IO.Path]::Combine('$(TailwindDestinationFolder)', '$(TailwindReleaseName)'))</TailwindCliPath>
     </PropertyGroup>
 
-    <!-- Download the file -->
-    <DownloadFile DestinationFolder="$([System.IO.Path]::Combine('$(TailwindDownloadPath)', 'Tailwind', '$(TailwindVersion)'))"
+    <!-- Download the file if it hasn't been already -->
+    <!-- Note: Using latest will always reach out to GitHub to see if a new version is available -->
+    <DownloadFile DestinationFolder="$(TailwindDestinationFolder)"
                   DestinationFileName="$(TailwindReleaseName)"
                   SourceUrl="$(TailwindDownloadUrl)"
                   SkipUnchangedFiles="true"
-                  Retries="3">
+                  Retries="3"
+                  Condition="'$(TailwindVersion)' == 'latest' Or !Exists('$(TailwindCliPath)')">
       <Output TaskParameter="DownloadedFile" PropertyName="TailwindCliPath"/>
     </DownloadFile>
 


### PR DESCRIPTION
This PR introduces a small change to the build process that enables building while offline, especially in scenarios where the CLI has already been downloaded. 