### PR TITLE
Delete output stylesheet during project clean

### DIFF
--- a/Tailwind.Standalone.csproj
+++ b/Tailwind.Standalone.csproj
@@ -10,7 +10,7 @@
 
     <Authors>Marshal Hayes</Authors>
     <PackageId>MarshalHayes.Tailwind.Standalone</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Description>Use the Tailwind Standalone CLI the right way</Description>
     
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/build/MarshalHayes.Tailwind.Standalone.targets
+++ b/build/MarshalHayes.Tailwind.Standalone.targets
@@ -110,4 +110,9 @@
 
     <Exec Command="$(TailwindBuildCommand)"/>
   </Target>
+
+  <!-- Delete the output stylesheet when cleaning the project -->
+  <Target Name="CleanTailwindOutput" AfterTargets="Clean">
+    <Delete Files="$(TailwindOutputStyleSheetPath)" Condition="Exists('$(TailwindOutputStyleSheetPath)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
This PR introduces an additional target which will delete the output stylesheet when the project/solution is cleaned.